### PR TITLE
Fix install requires, remove setup requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ setup(
 	description="Interface library for minimalist autograding site",
 	python_requires=">=3.5",
 	url="http://github.com/locuslab/mugrade",
-	install_requires=["numpy >= 1.15"],
-	setup_requires=["numpy >= 1.15"]
+	install_requires=[
+		"numpy >= 1.15",
+		"requests >= 2.25.1",
+	],
 )
 


### PR DESCRIPTION
## Issue

After installing mugrade and using it for the first time, you encounter a "missing requests library" error.

## Solution

This is because the requests package is not specified in the install_requires stage of the `setup.py`. Additionally, `setup_requires` can be omitted since the `setup.py` script itself does not require numpy to run. (i.e. you need numpy to install the package in the first place)

## Tests

I tested this locally on my machine